### PR TITLE
Used http-socket setting rather than socket for localhost

### DIFF
--- a/WSGIquickstart.rst
+++ b/WSGIquickstart.rst
@@ -133,7 +133,7 @@ Now we can spawn uWSGI to natively speak the uwsgi protocol:
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --wsgi-file foobar.py --master --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --http-socket 127.0.0.1:3031 --wsgi-file foobar.py --master --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 If you'll run ``ps aux``, you will see one process less. The HTTP router has been removed as our "workers" (the processes assigned to uWSGI)
 natively speak the uwsgi protocol.
@@ -162,7 +162,7 @@ We suppose the Django project is in ``/home/foobar/myproject``:
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --wsgi-file myproject/wsgi.py --master --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --http-socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --wsgi-file myproject/wsgi.py --master --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 (with ``--chdir`` we move to a specific directory). In Django this is required to correctly load modules.
 
@@ -172,7 +172,7 @@ Never fear! uWSGI supports various configuration styles. In this quickstart we w
 .. code-block:: ini
 
     [uwsgi]
-    socket = 127.0.0.1:3031
+    http-socket = 127.0.0.1:3031
     chdir = /home/foobar/myproject/
     wsgi-file = myproject/wsgi.py
     processes = 4
@@ -192,14 +192,14 @@ using an old (< 1.4) version of Django. In such a case you need a little bit mor
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --pythonpath .. --env DJANGO_SETTINGS_MODULE=myproject.settings --module "django.core.handlers.wsgi:WSGIHandler()" --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --http-socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --pythonpath .. --env DJANGO_SETTINGS_MODULE=myproject.settings --module "django.core.handlers.wsgi:WSGIHandler()" --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 Or, using the .ini file:
 
 .. code-block:: ini
 
    [uwsgi]
-   socket = 127.0.0.1:3031
+   http-socket = 127.0.0.1:3031
    chdir = /home/foobar/myproject/
    pythonpath = ..
    env = DJANGO_SETTINGS_MODULE=myproject.settings
@@ -234,7 +234,7 @@ We still continue to use the 4 processes/2 threads and the uwsgi socket as the b
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --wsgi-file myflaskapp.py --callable app --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --http-socket 127.0.0.1:3031 --wsgi-file myflaskapp.py --callable app --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 (the only addition is the ``--callable`` option).
 


### PR DESCRIPTION
When using an IP address it makes more sense to use the --`http-socket` or` http` cli parameter / ini setting. Sockets usually relate to files on the system.

I ran into an issue by following the documentation. When I started the uwsgi server an error occured: `invalid request block size: 21573 (max 8192)...skip` The first intuitive change was to increase the block size in order to handle the large header of the request.

I stumbled over [this](https://stackoverflow.com/a/21182437/7145511) and assume that more people fail to start the server for the first time.

The commit is equally unperfect as choosing between: socket, http and http-socket is dependent on the individual set-up. Nevertheless I would change this as default as the error message regarding block size is misleading.

If desired I can add a cross link to the sections where the difference between the three is explained.